### PR TITLE
fix: make execute non-payable

### DIFF
--- a/src/BaseInvoker.sol
+++ b/src/BaseInvoker.sol
@@ -24,7 +24,7 @@ abstract contract BaseInvoker is Auth {
     /// @param execData - arbitrary bytes containing Invoker-specific logic
     /// @param authority - signer to AUTH
     /// @param signature - signature input
-    function execute(bytes memory execData, address authority, Signature memory signature) external payable {
+    function execute(bytes memory execData, address authority, Signature memory signature) external {
         // AUTH this contract to execute the Batch on behalf of the authority
         auth(authority, keccak256(execData), signature);
         // execute Invoker operations, which may use AUTHCALL

--- a/src/BaseInvoker.sol
+++ b/src/BaseInvoker.sol
@@ -6,7 +6,7 @@ import { Auth } from "src/Auth.sol";
 /// @title BaseInvoker
 /// @author Anna Carroll <https://github.com/anna-carroll/3074>
 /// @author Jake Moxey <https://github.com/jxom>
-/// @notice Invoker contract template. 
+/// @notice Invoker contract template.
 /// @dev Inherit & override the `exec` function to implement arbitrary Invoker logic.
 abstract contract BaseInvoker is Auth {
     /// @notice produce a digest to sign that authorizes the invoker

--- a/test/Auth.t.sol
+++ b/test/Auth.t.sol
@@ -47,7 +47,7 @@ contract AuthTest is Test {
 
     function test_auth_revert_invalidAuthority(bytes32 commit) external {
         vm.pauseGasMetering();
-        
+
         uint64 nonce = vm.getNonce(address(authority.addr));
 
         bytes32 hash = target.getDigest(commit, nonce);

--- a/test/BatchInvoker.t.sol
+++ b/test/BatchInvoker.t.sol
@@ -108,7 +108,7 @@ contract BatchInvokerTest is Test {
         assertEq(callee.counter(authority.addr), 3);
         assertEq(callee.values(authority.addr), 6 ether);
     }
-    
+
     function test_execute_broadcastAsAuthority() external {
         vm.pauseGasMetering();
 


### PR DESCRIPTION
Since value is no longer transferred through the Invoker, the person submitting the transaction probably has no valid reason to send ether to this function