### PR TITLE
fix: added docker accessing host networking notes + cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Deploy the `BatchInvoker` contract to the network.
 make cmd="forge script Deploy --sig 'deploy()' --rpc-url $RPC_URL --private-key $EXECUTOR_PRIVATE_KEY --broadcast"
 ```
 
+**Note:** if the `$RPC_URL` you're pointing to is on host, you should use http://host.docker.internal:8545 instead of http://localhost:8545. See Docker's networking docs [here](https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host).
+
 #### 3. Test Invoker
 
 We can test the `BatchInvoker` by sending a transaction via the contract.

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -6,7 +6,7 @@ import { BatchInvoker } from "../src/BatchInvoker.sol";
 
 contract Deploy is Script {
     // deploy:
-    // ./bin/forge script Deploy --sig "deploy()" --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast
+    // make cmd="forge script Deploy --sig 'deploy()' --rpc-url $RPC_URL --private-key $EXECUTOR_PRIVATE_KEY --broadcast"
     function deploy() public {
         vm.broadcast();
         new BatchInvoker();

--- a/script/Execute.s.sol
+++ b/script/Execute.s.sol
@@ -12,6 +12,7 @@ contract Executor is Script, Test {
     uint256 apk = vm.envUint("AUTHORITY_PRIVATE_KEY");
     uint256 epk = vm.envUint("EXECUTOR_PRIVATE_KEY");
 
+    // script that signs auth message and calls `execute` on invoker
     function signAndExecute(address invoker, bytes memory execData) public {
         // construct the digest from execData
         bytes32 digest = BaseInvoker(invoker).getDigest(execData, vm.getNonce(vm.addr(apk)));


### PR DESCRIPTION
`foundry-alphanet`'s docker execution causes weird side effects when trying to access a host rpc endpoint, so I added a note to clarify.